### PR TITLE
feat: add source option for openr1 verifiable code dataset.

### DIFF
--- a/examples/configs/evals/openr1_verifiable_code.yaml
+++ b/examples/configs/evals/openr1_verifiable_code.yaml
@@ -5,6 +5,7 @@ data:
   prompt_file: "examples/prompts/openr1_verifiable_code.txt"
   dataset_name: "openr1_verifiable_code"
   code_exe_dir: "/tmp/logs"
+  source: "code_contests"
 
 generation:
   temperature: 0.7
@@ -19,3 +20,4 @@ env:
     num_workers: 8
     terminate_on_evaluation: true
     worker_type: "python_stdout_verify"
+    timeout: 3.0

--- a/nemo_rl/data/eval_datasets/__init__.py
+++ b/nemo_rl/data/eval_datasets/__init__.py
@@ -185,6 +185,7 @@ def load_eval_dataset(data_config):
         )
     elif dataset_name == "openr1_verifiable_code":
         base_dataset = OpenR1VerifiableCodeDataset(
+            source=data_config["source"],
             code_exe_dir=data_config["code_exe_dir"],
             prompt_file=data_config["prompt_file"],
             system_prompt_file=data_config["system_prompt_file"],


### PR DESCRIPTION
# What does this PR do ?

**Support `source` option inside OpenR1 code dataset.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)): N/A


# Usage
* **Run eval on the `apps` subset from OpenR1 code dataset.**

```python
uv run examples/run_eval.py --config examples/configs/evals/openr1_verifiable_code.yaml generation.num_prompts_per_step=-1 data.source="apps" cluster.gpus_per_node=8
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
