### PR TITLE
feat: Make concurrent async calls to GPT grader model in Alpaca 2.0 Eval.

### DIFF
--- a/examples/configs/evals/alpaca2.yaml
+++ b/examples/configs/evals/alpaca2.yaml
@@ -17,8 +17,10 @@ data:
 
 env:
   math:
+    num_workers: 1
     worker_type: "alpaca2"
     grader_model_name: "gpt-4-1106-preview"
+    grader_batch_size: 25
     grader_max_tokens: 1
     grader_temperature: 1
     grader_logprobs: true

--- a/examples/configs/evals/alpaca2.yaml
+++ b/examples/configs/evals/alpaca2.yaml
@@ -20,7 +20,7 @@ env:
     num_workers: 1
     worker_type: "alpaca2"
     grader_model_name: "gpt-4-1106-preview"
-    grader_batch_size: 25
+    grader_batch_size: 805
     grader_max_tokens: 1
     grader_temperature: 1
     grader_logprobs: true

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -478,7 +478,7 @@ class Alpaca2VerifyWorker:
             self.grader_model = GptGraderModel(
                 model=model,
                 api_key=cfg.get("grader_api_key", os.getenv("OPENAI_API_KEY")),
-                system_message=cfg.get("grader_system_message",ALPACA2_SYSTEM_MESSAGE),
+                system_message=cfg.get("grader_system_message", ALPACA2_SYSTEM_MESSAGE),
                 temperature=cfg.get("grader_temperature", 1.0),
                 max_tokens=cfg.get("grader_max_tokens", 1),
                 logprobs=cfg.get("grader_logprobs", 1),
@@ -488,7 +488,7 @@ class Alpaca2VerifyWorker:
             self.grader_model = GeminiGraderModel(
                 model=model,
                 api_key=cfg.get("grader_api_key", os.getenv("GEMINI_API_KEY")),
-                system_message=cfg.get("grader_system_message",ALPACA2_SYSTEM_MESSAGE),
+                system_message=cfg.get("grader_system_message", ALPACA2_SYSTEM_MESSAGE),
                 temperature=cfg.get("grader_temperature", 1.0),
                 max_tokens=cfg.get("grader_max_tokens", 1),
             )

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -464,14 +464,14 @@ async def _run_env_eval_impl(
             )
         elif metric == "length_controlled_winrate":
             annotations = []
-            for response, verdict, observation in zip(
+            for response, judge_prefers_sample, observation in zip(
                 output_texts,
                 rewards,
                 env_return.observations,
             ):
                 golden_response = observation.get("correct_answer", None)
                 annotation = {
-                    "preference": 2 if verdict else 1,
+                    "preference": 2 if judge_prefers_sample else 1,
                     "annotator": master_config["env"]["math"]["grader_model_name"],
                     "generator_1": "gpt4_1106_preview",
                     "generator_2": master_config["generation"]["model_name"],


### PR DESCRIPTION
# What does this PR do ?

Make concurrent async calls to GPT grader model in Alpaca 2.0 Eval.

# Usage
Added a `grader_batch_size` field in eval math env config. Run Alpaca 2.0 Eval command:
```python
uv run python examples/run_eval.py \
--config examples/configs/evals/alpaca2.yaml \
generation.model_name={model_name}
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (No new tests.)
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests (Existing tests still pass.)
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.